### PR TITLE
update go.mod version for imports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/Seagate/gofish
 
-replace github.com/stmcginnis/gofish => github.com/Seagate/gofish v0.13.0
-
 go 1.19
 
-require github.com/stmcginnis/gofish v0.0.0-00010101000000-000000000000
+require github.com/stmcginnis/gofish v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/Seagate/gofish v0.13.0 h1:WBG9Gv/qV4AjRUN6m0t9lHnGuWDuexKZUIVZpjokj5w=
-github.com/Seagate/gofish v0.13.0/go.mod h1:BLDSFTp8pDlf/xDbLZa+F7f7eW0E/CHCboggsu8CznI=
+github.com/stmcginnis/gofish v0.13.0 h1:qq6q3yNt9vw7ZuJxiw87hq9+BdPLsuRQBwl+XoZSz60=
+github.com/stmcginnis/gofish v0.13.0/go.mod h1:BLDSFTp8pDlf/xDbLZa+F7f7eW0E/CHCboggsu8CznI=


### PR DESCRIPTION
Update the go.mod so other products can import github.com/Seagate/gofish
- Removed the "replace" operation and updated the version for stmcginnis/gofish
